### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ blacktop/ghidra          9.0                 1.18GB
 
 #### On macOS
 
-1. Install XQuartz `brew cask install xquartz`
+1. Install XQuartz `brew install xquartz`
 2. Install socat `brew install socat`
-3. `open -a XQuartz` and make sure you **"Allow connections from network clients"**
-4. Now add the IP using Xhost with: `xhost + 127.0.0.1` or `xhost + $(ipconfig getifaddr en0)`
+3. `open -a XQuartz` and make sure you **"Allow connections from network clients"** (in XQuartz > Preferences... > Security)
+4. Now add the IP using Xhost with: `xhost + 127.0.0.1`
 5. Start socat `socat TCP-LISTEN:6000,reuseaddr,fork UNIX-CLIENT:\"$DISPLAY\"`
 6. Start up Ghidra
 


### PR DESCRIPTION
- changed the Homebrew command to install XQuartz (using "cask" is no longer necessary)
- clarified where in XQuartz settings to "Allow connections from network clients"
- removed unnecessary xhost command (the address of en0 interface should be irrelevant as the connection from socat should use the loopback)

(someone please verify it works on a clean installation) ;-)